### PR TITLE
Pass previous value to onChange callback

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] 2024-05-30
+
+### Changed
+
+- onChange callback now has access to the previous context's value
+
 ## [1.2.1] 2023-04-20
 
 ### Updated
@@ -33,10 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[unreleased]: https://github.com/saasquatch/squatch-js/compare/@saasquatch%2Fdom-context@1.2.1...HEAD
-[1.2.1]: https://github.com/saasquatch/squatch-js/compare/v1.2.0...@saasquatch%2Fdom-context@1.2.1
-[1.2.0]: https://github.com/saasquatch/squatch-js/compare/v1.0.1...v1.2.0
-[1.0.1]: https://github.com/saasquatch/squatch-js/compare/V1.0.0...V1.0.1
-[1.0.0]: https://github.com/saasquatch/squatch-js/compare/0.0.5...V1.0.0
-[0.0.5]: https://github.com/saasquatch/squatch-js/compare/0.0.3...0.0.5
+[unreleased]: https://github.com/saasquatch/dom-context/compare/@saasquatch%2Fdom-context@1.3.0...HEAD
+[1.3.0]: https://github.com/saasquatch/dom-context/compare/v1.2.1...@saasquatch%2Fdom-context@1.3.0
+[1.2.1]: https://github.com/saasquatch/dom-context/compare/v1.2.0...@saasquatch%2Fdom-context@1.2.1
+[1.2.0]: https://github.com/saasquatch/dom-context/compare/v1.0.1...v1.2.0
+[1.0.1]: https://github.com/saasquatch/dom-context/compare/V1.0.0...V1.0.1
+[1.0.0]: https://github.com/saasquatch/dom-context/compare/0.0.5...V1.0.0
+[0.0.5]: https://github.com/saasquatch/dom-context/compare/0.0.3...0.0.5
 [0.0.3]: https://github.com/saasquatch/dom-context/releases/tag/0.0.3

--- a/__tests__/Connection.feature
+++ b/__tests__/Connection.feature
@@ -27,6 +27,7 @@ Feature: Connection between providers and listeners
         And a listener is connected
         When the provider sets a new value
         Then the listener recieves the new value via `onChange`
+        And the listener recieves the previous value via `onChange`
 
     Scenario: Listener should stop polling when disconnected
         Given a listener is started inside of the nested div

--- a/__tests__/Connection.feature
+++ b/__tests__/Connection.feature
@@ -26,8 +26,8 @@ Feature: Connection between providers and listeners
         And the provider is started
         And a listener is connected
         When the provider sets a new value
-        Then the listener recieves the new value via `onChange`
-        And the listener recieves the previous value via `onChange`
+        Then the listener receives the new value via `onChange`
+        And the listener receives the previous value via `onChange`
 
     Scenario: Listener should stop polling when disconnected
         Given a listener is started inside of the nested div

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dom-context",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dom-context",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@saasquatch/scoped-autobindsteps": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dom-context",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A context library for web components and vanilla dom",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export type RequestEvent<T> = CustomEvent<Detail<T>>;
 
 export type Resolve<T> = (value?: T | PromiseLike<T>) => void;
 export type PromiseFactory<T> = (val: T) => Promise<unknown>;
-export type OnChange<T> = (val: T) => unknown;
+export type OnChange<T> = (val: T, prev?: T) => unknown;
 export type Accessor<T> = () => T;
 export type AccessorOrValue<T> = Accessor<T> | T;
 
@@ -232,14 +232,14 @@ export class ContextListener<T> {
   }
 
   /* called by provider */
-  onChange = (context: T) => {
-    this.options.onChange && this.options.onChange(context);
+  onChange = (context: T, previous?: T) => {
+    this.options.onChange && this.options.onChange(context, previous);
   };
 
   /* called by provider */
   onConnect = async (context: T) => {
     this.status = ListenerConnectionStatus.CONNECTED;
-    this.options.onChange && this.options.onChange(context);
+    this.options.onChange && this.options.onChange(context, undefined);
     return new Promise((resolve) => {
       this.resolvePromise = resolve;
     });
@@ -324,8 +324,9 @@ export class ContextProvider<T> {
    * Set a new value for context and provides it to all subscribed listeners
    */
   set context(next: T) {
+    const prev = this.__current;
     this.__current = next;
-    this.__listeners.forEach((consumer) => consumer.onChange(next));
+    this.__listeners.forEach((consumer) => consumer.onChange(next, prev));
   }
 
   /**


### PR DESCRIPTION
## Description of the change

> This PR adds the previous context value as an optional parameter to the onChange callback. This solves an issue we've run into where we aren't able to ignore the `onChange` side-effect that occurs during the `onConnect` function (i.e. on initialisation).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Development tools (readme, specs, tests, code formatting)

## Links

- Jira issue number: (PUT IT HERE)
- Process.st launch checklist: (PUT IT HERE)

## Checklists

### Development

- [x] [Prettier](https://www.npmjs.com/package/prettier) was run (if applicable)
- [x] The behaviour changes in the pull request are covered by specs
- [ ] All tests related to the changed code pass in development

### Paperwork

- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has a Jira number
- [ ] This pull request has a Process.st launch checklist

### Code review

- [ ] Changes have been reviewed by at least one other engineer
- [ ] Security impacts of this change have been considered
